### PR TITLE
Remove dependency on opal-parser

### DIFF
--- a/lib/glimmer-dsl-web.rb
+++ b/lib/glimmer-dsl-web.rb
@@ -48,7 +48,6 @@ else
     end
   end
   
-  require 'opal-parser'
   require 'native' # move this to opal-async
   require 'opal-async'
   require 'async/ext'


### PR DESCRIPTION
This commit modifies a GlimmerHelper to compile Opal server-side. In addition to that, it memoizes the glimmer_component method, so that code is not compiled multiple times.

This allows us to remove an `opal-parser` dependency, so that bundle size of a sample application can be reduced by more than 50%:

Before: 712.64kiB compressed, 4.77MiB uncompressed
After: 339kiB compressed, 2.1MiB uncompressed

Unfortunately, this also moves the requirement for users of Glimmer DSL for Web to manually `require "opal-parser"` if they decide to use `eval`, `instance_eval` etc. This is not a big issue, as a descriptive error gets dropped in a web console.